### PR TITLE
Pacote subcaption e cmap

### DIFF
--- a/cap2.tex
+++ b/cap2.tex
@@ -15,6 +15,19 @@ Essa é uma seção da sua tese.
     \label{fig:log_unicamp}
 \end{figure}
 
+Figuras também podem ter subfiguras, usando o pacote \texttt{subcaption}, que 
+podem ser citadas individualmente: figura~\ref{fig:caption1}.
+\begin{figure}[!htb]
+    \centering
+    \subcaptionbox{\emph{Caption} 1.\label{fig:caption1}}
+        {\includegraphics[width=0.45\textwidth]{figuras/unicamp-logo.jpg}}
+    \qquad
+    \subcaptionbox{\emph{Caption} 1.\label{fig:caption2}}
+        {\includegraphics[width=0.45\textwidth]{figuras/unicamp-logo.jpg}}
+    \caption{Figura com subfiguras.}
+    \label{fig:subfig}
+\end{figure}
+
 Além de inserir figuras é possível ``desenhar''\index{figura!desenhar} figuras utilizando o pacote
 TikZ\index{figura!TikZ}, como na Figura~\ref{fig:exem_tikz}.
 \begin{figure}[!htb]

--- a/pacotes.tex
+++ b/pacotes.tex
@@ -2,6 +2,8 @@
 % FIXME Selecione a codificação adequada.
 \usepackage[utf8]{inputenc}
 % \usepackage[latin1]{inputenc}
+\usepackage{cmap}
+\usepackage[noTeX]{mmap}
 \usepackage[T1]{fontenc}
 \usepackage[brazilian]{babel}
 \usepackage{indentfirst}

--- a/pacotes.tex
+++ b/pacotes.tex
@@ -35,6 +35,7 @@
 \usepackage{graphicx}
 \usepackage{tikz}
 \usepackage{wrapfig}
+\usepackage{subcaption}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%% Pacotes: algoritmos %%%%%%%%%%%%%%%%%%%%%%%%%%%%% 

--- a/pacotes.tex
+++ b/pacotes.tex
@@ -3,7 +3,6 @@
 \usepackage[utf8]{inputenc}
 % \usepackage[latin1]{inputenc}
 \usepackage{cmap}
-\usepackage[noTeX]{mmap}
 \usepackage[T1]{fontenc}
 \usepackage[brazilian]{babel}
 \usepackage{indentfirst}


### PR DESCRIPTION
O pacote `subcaption` é usando para a inclusão de diversas figuras citáveis em um único ambiente _figure_. Veja o [manual](http://mirrors.ctan.org/macros/latex/contrib/caption/subcaption.pdf) ou a [seção da wikibooks sobre floats](http://en.wikibooks.org/wiki/LaTeX/Floats,_Figures_and_Captions#Subfloats).

O pacote `cmap` permite que certos carácteres sejam buscáveis no PDF final. Por exemplo, a palavra "Cientíﬁca" tem a ligadura "ﬁ" que não é copiada corretamente do PDF. Com o pacote, a ligadura "ﬁ" se transforma nas duas letras "fi".
