### PR TITLE
Adicionado o pacote lmodern.

### DIFF
--- a/pacotes.tex
+++ b/pacotes.tex
@@ -59,6 +59,7 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Pacotes: fontes %%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
+\usepackage{lmodern}
 \usepackage{mathrsfs}
 
 


### PR DESCRIPTION
Aqui vão alguns recursos que explicam toda essa lambança de Latin/Computer Modern.

Primeiro, há a página na Wikibooks do LaTeX explicando o que é a codificação de fontes e por que se deve usar Latin Modern ou CM-Super quando há caracteres acentuados.
http://en.wikibooks.org/wiki/LaTeX/Fonts#Font_encoding
Recomendo na verdade ler toda a página para os interessados.

Depois, tem a pergunta do StackOverflow explicando qual a diferença do CM-Super e do Latin Modern e por que normalmente se recomenda usar o Latin Modern
http://tex.stackexchange.com/questions/1390/latin-modern-vs-cm-super

Finalmente, para aquele que se amarram em uma documentação, segue a doc do pacote Latin Modern
http://www.ctan.org/tex-archive/fonts/lm/

Destes, os arquivos mais interessantes são
http://mirrors.ctan.org/fonts/lm/doc/fonts/lm/README-Latin-Modern.TXT
e
http://mirrors.ctan.org/fonts/lm/doc/fonts/lm/lm-info.pdf
